### PR TITLE
feat: don't compute input source maps if source file hasn't changed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,5 @@
 node_modules/
 build/
-dist/
 coverage/
 *.log
 .eslintcache
@@ -10,7 +9,6 @@ logs
 npm-debug.log*
 yarn-debug.log*
 /coverage
-/dist
 /local
 /reports
 /node_modules

--- a/dist/TaskRunner.js
+++ b/dist/TaskRunner.js
@@ -1,0 +1,122 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _os = _interopRequireDefault(require("os"));
+
+var _cacache = _interopRequireDefault(require("cacache"));
+
+var _findCacheDir = _interopRequireDefault(require("find-cache-dir"));
+
+var _workerFarm = _interopRequireDefault(require("worker-farm"));
+
+var _serializeJavascript = _interopRequireDefault(require("serialize-javascript"));
+
+var _minify = _interopRequireDefault(require("./minify"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+const workerFile = require.resolve('./worker');
+
+class TaskRunner {
+  constructor(options = {}) {
+    const {
+      cache,
+      parallel
+    } = options;
+    this.cacheDir = cache === true ? (0, _findCacheDir.default)({
+      name: 'uglifyjs-webpack-plugin'
+    }) : cache; // In some cases cpus() returns undefined
+    // https://github.com/nodejs/node/issues/19022
+
+    const cpus = _os.default.cpus() || {
+      length: 1
+    };
+    this.maxConcurrentWorkers = parallel === true ? cpus.length - 1 : Math.min(Number(parallel) || 0, cpus.length - 1);
+  }
+
+  run(tasks, callback) {
+    /* istanbul ignore if */
+    if (!tasks.length) {
+      callback(null, []);
+      return;
+    }
+
+    if (this.maxConcurrentWorkers > 1) {
+      const workerOptions = process.platform === 'win32' ? {
+        maxConcurrentWorkers: this.maxConcurrentWorkers,
+        maxConcurrentCallsPerWorker: 1
+      } : {
+        maxConcurrentWorkers: this.maxConcurrentWorkers
+      };
+      this.workers = (0, _workerFarm.default)(workerOptions, workerFile);
+
+      this.boundWorkers = (options, cb) => {
+        try {
+          this.workers((0, _serializeJavascript.default)(options), cb);
+        } catch (error) {
+          // worker-farm can fail with ENOMEM or something else
+          cb(error);
+        }
+      };
+    } else {
+      this.boundWorkers = (options, cb) => {
+        try {
+          cb(null, (0, _minify.default)(options));
+        } catch (error) {
+          cb(error);
+        }
+      };
+    }
+
+    let toRun = tasks.length;
+    const results = [];
+
+    const step = (index, data) => {
+      toRun -= 1;
+      results[index] = data;
+
+      if (!toRun) {
+        callback(null, results);
+      }
+    };
+
+    tasks.forEach((task, index) => {
+      const enqueue = () => {
+        this.boundWorkers(task, (error, data) => {
+          const result = error ? {
+            error
+          } : data;
+
+          const done = () => step(index, result);
+
+          if (this.cacheDir && !result.error) {
+            _cacache.default.put(this.cacheDir, task.cacheKey, JSON.stringify(data)).then(done, done);
+          } else {
+            done();
+          }
+        });
+      };
+
+      if (this.cacheDir) {
+        _cacache.default.get(this.cacheDir, task.cacheKey).then(({
+          data
+        }) => step(index, JSON.parse(data)), enqueue);
+      } else {
+        enqueue();
+      }
+    });
+  }
+
+  exit() {
+    if (this.workers) {
+      _workerFarm.default.end(this.workers);
+    }
+  }
+
+}
+
+exports.default = TaskRunner;

--- a/dist/cjs.js
+++ b/dist/cjs.js
@@ -1,0 +1,5 @@
+"use strict";
+
+const plugin = require('./index');
+
+module.exports = plugin.default;

--- a/dist/index.js
+++ b/dist/index.js
@@ -1,0 +1,375 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _crypto = _interopRequireDefault(require("crypto"));
+
+var _path = _interopRequireDefault(require("path"));
+
+var _sourceMap = require("source-map");
+
+var _webpackSources = require("webpack-sources");
+
+var _RequestShortener = _interopRequireDefault(require("webpack/lib/RequestShortener"));
+
+var _ModuleFilenameHelpers = _interopRequireDefault(require("webpack/lib/ModuleFilenameHelpers"));
+
+var _schemaUtils = _interopRequireDefault(require("schema-utils"));
+
+var _serializeJavascript = _interopRequireDefault(require("serialize-javascript"));
+
+var _package = _interopRequireDefault(require("uglify-js/package.json"));
+
+var _cacache = _interopRequireDefault(require("cacache"));
+
+var _findCacheDir = _interopRequireDefault(require("find-cache-dir"));
+
+var _options = _interopRequireDefault(require("./options.json"));
+
+var _TaskRunner = _interopRequireDefault(require("./TaskRunner"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function asyncGeneratorStep(gen, resolve, reject, _next, _throw, key, arg) { try { var info = gen[key](arg); var value = info.value; } catch (error) { reject(error); return; } if (info.done) { resolve(value); } else { Promise.resolve(value).then(_next, _throw); } }
+
+function _asyncToGenerator(fn) { return function () { var self = this, args = arguments; return new Promise(function (resolve, reject) { var gen = fn.apply(self, args); function _next(value) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "next", value); } function _throw(err) { asyncGeneratorStep(gen, resolve, reject, _next, _throw, "throw", err); } _next(undefined); }); }; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+const warningRegex = /\[.+:([0-9]+),([0-9]+)\]/;
+
+class UglifyJsPlugin {
+  constructor(options = {}) {
+    (0, _schemaUtils.default)(_options.default, options, 'UglifyJs Plugin');
+    const {
+      minify,
+      uglifyOptions = {},
+      test = /\.js(\?.*)?$/i,
+      chunkFilter = () => true,
+      warningsFilter = () => true,
+      extractComments = false,
+      sourceMap = false,
+      cache = false,
+      cacheKeys = defaultCacheKeys => defaultCacheKeys,
+      parallel = false,
+      include,
+      exclude
+    } = options;
+    this.options = {
+      test,
+      chunkFilter,
+      warningsFilter,
+      extractComments,
+      sourceMap,
+      cache,
+      cacheKeys,
+      parallel,
+      include,
+      exclude,
+      minify,
+      uglifyOptions: _objectSpread({
+        output: {
+          comments: extractComments ? false : /^\**!|@preserve|@license|@cc_on/i
+        }
+      }, uglifyOptions)
+    };
+  }
+
+  static isSourceMap(input) {
+    // All required options for `new SourceMapConsumer(...options)`
+    // https://github.com/mozilla/source-map#new-sourcemapconsumerrawsourcemap
+    return Boolean(input && input.version && input.sources && Array.isArray(input.sources) && typeof input.mappings === 'string');
+  }
+
+  static buildSourceMap(inputSourceMap) {
+    if (!inputSourceMap || !UglifyJsPlugin.isSourceMap(inputSourceMap)) {
+      return null;
+    }
+
+    return new _sourceMap.SourceMapConsumer(inputSourceMap);
+  }
+
+  static buildError(err, file, sourceMap, requestShortener) {
+    // Handling error which should have line, col, filename and message
+    if (err.line) {
+      const original = sourceMap && sourceMap.originalPositionFor({
+        line: err.line,
+        column: err.col
+      });
+
+      if (original && original.source && requestShortener) {
+        return new Error(`${file} from UglifyJs\n${err.message} [${requestShortener.shorten(original.source)}:${original.line},${original.column}][${file}:${err.line},${err.col}]`);
+      }
+
+      return new Error(`${file} from UglifyJs\n${err.message} [${file}:${err.line},${err.col}]`);
+    } else if (err.stack) {
+      return new Error(`${file} from UglifyJs\n${err.stack}`);
+    }
+
+    return new Error(`${file} from UglifyJs\n${err.message}`);
+  }
+
+  static buildWarning(warning, file, sourceMap, requestShortener, warningsFilter) {
+    let warningMessage = warning;
+    let locationMessage = '';
+    let source = null;
+
+    if (sourceMap) {
+      const match = warningRegex.exec(warning);
+
+      if (match) {
+        const line = +match[1];
+        const column = +match[2];
+        const original = sourceMap.originalPositionFor({
+          line,
+          column
+        });
+
+        if (original && original.source && original.source !== file && requestShortener) {
+          ({
+            source
+          } = original);
+          warningMessage = `${warningMessage.replace(warningRegex, '')}`;
+          locationMessage = `[${requestShortener.shorten(original.source)}:${original.line},${original.column}]`;
+        }
+      }
+    }
+
+    if (warningsFilter && !warningsFilter(warning, source)) {
+      return null;
+    }
+
+    return `UglifyJs Plugin: ${warningMessage}${locationMessage}`;
+  }
+
+  apply(compiler) {
+    var _this = this;
+
+    const buildModuleFn = moduleArg => {
+      // to get detailed location info about errors
+      moduleArg.useSourceMap = true;
+    };
+
+    const optimizeFn = (compilation, chunks, callback) => {
+      const taskRunner = new _TaskRunner.default({
+        cache: this.options.cache,
+        parallel: this.options.parallel
+      });
+      const processedAssets = new WeakSet();
+      const tasks = [];
+      const {
+        chunkFilter
+      } = this.options;
+      const cacheDir = (0, _findCacheDir.default)({
+        name: 'uglifyjs-webpack-plugin'
+      });
+      const promise = Promise.all(Array.from(chunks).filter(chunk => chunkFilter && chunkFilter(chunk)).reduce((acc, chunk) => acc.concat(chunk.files || []), []).concat(compilation.additionalChunkAssets || []).filter(_ModuleFilenameHelpers.default.matchObject.bind(null, this.options)).map(
+      /*#__PURE__*/
+      function () {
+        var _ref = _asyncToGenerator(function* (file) {
+          let inputSourceMap;
+          const asset = compilation.assets[file];
+
+          if (processedAssets.has(asset)) {
+            return;
+          }
+
+          try {
+            let cacheKey;
+            let cacheHit = false;
+            const input = asset.source();
+
+            if (_this.options.cache) {
+              const defaultCacheKeys = {
+                // eslint-disable-next-line global-require
+                'uglify-js': _package.default.version,
+                // eslint-disable-next-line global-require
+                'uglifyjs-webpack-plugin': require('../package.json').version,
+                'uglifyjs-webpack-plugin-options': _this.options,
+                hash: _crypto.default.createHash('md4').update(input).digest('hex')
+              };
+              cacheKey = _this.options.cacheKeys ? (0, _serializeJavascript.default)(_this.options.cacheKeys(defaultCacheKeys, file)) : defaultCacheKeys;
+              cacheHit = !!(yield _cacache.default.get.info(cacheDir, cacheKey));
+            }
+
+            if (_this.options.sourceMap && asset.map && !cacheHit) {
+              const map = asset.map(_this.options);
+
+              if (UglifyJsPlugin.isSourceMap(map)) {
+                inputSourceMap = map;
+              } else {
+                inputSourceMap = map;
+                compilation.warnings.push(new Error(`${file} contains invalid source map`));
+              }
+            } else {
+              inputSourceMap = null;
+            } // Handling comment extraction
+
+
+            let commentsFile = false;
+
+            if (_this.options.extractComments) {
+              commentsFile = _this.options.extractComments.filename || `${file}.LICENSE`;
+
+              if (typeof commentsFile === 'function') {
+                commentsFile = commentsFile(file);
+              }
+            }
+
+            const task = {
+              file,
+              input,
+              inputSourceMap,
+              commentsFile,
+              extractComments: _this.options.extractComments,
+              uglifyOptions: _this.options.uglifyOptions,
+              minify: _this.options.minify,
+              cacheKey
+            };
+            tasks.push(task);
+          } catch (error) {
+            compilation.errors.push(UglifyJsPlugin.buildError(error, file, UglifyJsPlugin.buildSourceMap(inputSourceMap), new _RequestShortener.default(compiler.context)));
+          }
+        });
+
+        return function (_x) {
+          return _ref.apply(this, arguments);
+        };
+      }()));
+      promise.then(() => {
+        taskRunner.run(tasks, (tasksError, results) => {
+          if (tasksError) {
+            compilation.errors.push(tasksError);
+            return;
+          }
+
+          results.forEach((data, index) => {
+            const {
+              file,
+              input,
+              inputSourceMap,
+              commentsFile
+            } = tasks[index];
+            const {
+              error,
+              map,
+              code,
+              warnings
+            } = data;
+            let {
+              extractedComments
+            } = data;
+            let sourceMap = null;
+
+            if (error || warnings && warnings.length > 0) {
+              sourceMap = UglifyJsPlugin.buildSourceMap(inputSourceMap);
+            } // Handling results
+            // Error case: add errors, and go to next file
+
+
+            if (error) {
+              compilation.errors.push(UglifyJsPlugin.buildError(error, file, sourceMap, new _RequestShortener.default(compiler.context)));
+              return;
+            }
+
+            let outputSource;
+
+            if (map) {
+              outputSource = new _webpackSources.SourceMapSource(code, file, JSON.parse(map), input, inputSourceMap);
+            } else {
+              outputSource = new _webpackSources.RawSource(code);
+            } // Write extracted comments to commentsFile
+
+
+            if (commentsFile && extractedComments && extractedComments.length > 0) {
+              if (commentsFile in compilation.assets) {
+                const commentsFileSource = compilation.assets[commentsFile].source();
+                extractedComments = extractedComments.filter(comment => !commentsFileSource.includes(comment));
+              }
+
+              if (extractedComments.length > 0) {
+                // Add a banner to the original file
+                if (this.options.extractComments.banner !== false) {
+                  let banner = this.options.extractComments.banner || `For license information please see ${_path.default.posix.basename(commentsFile)}`;
+
+                  if (typeof banner === 'function') {
+                    banner = banner(commentsFile);
+                  }
+
+                  if (banner) {
+                    outputSource = new _webpackSources.ConcatSource(`/*! ${banner} */\n`, outputSource);
+                  }
+                }
+
+                const commentsSource = new _webpackSources.RawSource(`${extractedComments.join('\n\n')}\n`);
+
+                if (commentsFile in compilation.assets) {
+                  // commentsFile already exists, append new comments...
+                  if (compilation.assets[commentsFile] instanceof _webpackSources.ConcatSource) {
+                    compilation.assets[commentsFile].add('\n');
+                    compilation.assets[commentsFile].add(commentsSource);
+                  } else {
+                    compilation.assets[commentsFile] = new _webpackSources.ConcatSource(compilation.assets[commentsFile], '\n', commentsSource);
+                  }
+                } else {
+                  compilation.assets[commentsFile] = commentsSource;
+                }
+              }
+            } // Updating assets
+
+
+            processedAssets.add(compilation.assets[file] = outputSource); // Handling warnings
+
+            if (warnings && warnings.length > 0) {
+              warnings.forEach(warning => {
+                const builtWarning = UglifyJsPlugin.buildWarning(warning, file, sourceMap, new _RequestShortener.default(compiler.context), this.options.warningsFilter);
+
+                if (builtWarning) {
+                  compilation.warnings.push(builtWarning);
+                }
+              });
+            }
+          });
+          taskRunner.exit();
+          callback();
+        });
+      });
+    };
+
+    const plugin = {
+      name: this.constructor.name
+    };
+    compiler.hooks.compilation.tap(plugin, compilation => {
+      if (this.options.sourceMap) {
+        compilation.hooks.buildModule.tap(plugin, buildModuleFn);
+      }
+
+      const {
+        mainTemplate,
+        chunkTemplate
+      } = compilation; // Regenerate `contenthash` for minified assets
+
+      for (const template of [mainTemplate, chunkTemplate]) {
+        template.hooks.hashForChunk.tap(plugin, hash => {
+          const data = (0, _serializeJavascript.default)({
+            uglifyjs: _package.default.version,
+            uglifyjsOptions: this.options.uglifyOptions
+          });
+          hash.update('UglifyJsPlugin');
+          hash.update(data);
+        });
+      }
+
+      compilation.hooks.optimizeChunkAssets.tapAsync(plugin, optimizeFn.bind(this, compilation));
+    });
+  }
+
+}
+
+var _default = UglifyJsPlugin;
+exports.default = _default;

--- a/dist/minify.js
+++ b/dist/minify.js
@@ -1,0 +1,183 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", {
+  value: true
+});
+exports.default = void 0;
+
+var _uglifyJs = _interopRequireDefault(require("uglify-js"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+function _objectSpread(target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i] != null ? arguments[i] : {}; var ownKeys = Object.keys(source); if (typeof Object.getOwnPropertySymbols === 'function') { ownKeys = ownKeys.concat(Object.getOwnPropertySymbols(source).filter(function (sym) { return Object.getOwnPropertyDescriptor(source, sym).enumerable; })); } ownKeys.forEach(function (key) { _defineProperty(target, key, source[key]); }); } return target; }
+
+function _defineProperty(obj, key, value) { if (key in obj) { Object.defineProperty(obj, key, { value: value, enumerable: true, configurable: true, writable: true }); } else { obj[key] = value; } return obj; }
+
+const buildUglifyOptions = ({
+  warnings,
+  parse = {},
+  compress = {},
+  mangle,
+  output,
+  toplevel,
+  nameCache,
+  ie8,
+
+  /* eslint-disable camelcase */
+  keep_fnames
+  /* eslint-enable camelcase */
+
+} = {}) => ({
+  warnings,
+  parse: _objectSpread({}, parse),
+  compress: typeof compress === 'boolean' ? compress : _objectSpread({}, compress),
+  // eslint-disable-next-line no-nested-ternary
+  mangle: mangle == null ? true : typeof mangle === 'boolean' ? mangle : _objectSpread({}, mangle),
+  output: _objectSpread({
+    shebang: true,
+    comments: false,
+    beautify: false,
+    semicolons: true
+  }, output),
+  // Ignoring sourceMap from options
+  sourceMap: null,
+  toplevel,
+  nameCache,
+  ie8,
+  keep_fnames
+});
+
+const buildComments = (options, uglifyOptions, extractedComments) => {
+  const condition = {};
+  const commentsOpts = uglifyOptions.output.comments; // Use /^\**!|@preserve|@license|@cc_on/i RegExp
+
+  if (typeof options.extractComments === 'boolean') {
+    condition.preserve = commentsOpts;
+    condition.extract = /^\**!|@preserve|@license|@cc_on/i;
+  } else if (typeof options.extractComments === 'string' || options.extractComments instanceof RegExp) {
+    // extractComments specifies the extract condition and commentsOpts specifies the preserve condition
+    condition.preserve = commentsOpts;
+    condition.extract = options.extractComments;
+  } else if (typeof options.extractComments === 'function') {
+    condition.preserve = commentsOpts;
+    condition.extract = options.extractComments;
+  } else if (Object.prototype.hasOwnProperty.call(options.extractComments, 'condition')) {
+    // Extract condition is given in extractComments.condition
+    condition.preserve = commentsOpts;
+    condition.extract = options.extractComments.condition;
+  } else {
+    // No extract condition is given. Extract comments that match commentsOpts instead of preserving them
+    condition.preserve = false;
+    condition.extract = commentsOpts;
+  } // Ensure that both conditions are functions
+
+
+  ['preserve', 'extract'].forEach(key => {
+    let regexStr;
+    let regex;
+
+    switch (typeof condition[key]) {
+      case 'boolean':
+        condition[key] = condition[key] ? () => true : () => false;
+        break;
+
+      case 'function':
+        break;
+
+      case 'string':
+        if (condition[key] === 'all') {
+          condition[key] = () => true;
+
+          break;
+        }
+
+        if (condition[key] === 'some') {
+          condition[key] = (astNode, comment) => {
+            return comment.type === 'comment2' && /^\**!|@preserve|@license|@cc_on/i.test(comment.value);
+          };
+
+          break;
+        }
+
+        regexStr = condition[key];
+
+        condition[key] = (astNode, comment) => {
+          return new RegExp(regexStr).test(comment.value);
+        };
+
+        break;
+
+      default:
+        regex = condition[key];
+
+        condition[key] = (astNode, comment) => regex.test(comment.value);
+
+    }
+  }); // Redefine the comments function to extract and preserve
+  // comments according to the two conditions
+  // Redefine the comments function to extract and preserve
+  // comments according to the two conditions
+
+  return (astNode, comment) => {
+    if (condition.extract(astNode, comment)) {
+      const commentText = comment.type === 'comment2' ? `/*${comment.value}*/` : `//${comment.value}`; // Don't include duplicate comments
+
+      if (!extractedComments.includes(commentText)) {
+        extractedComments.push(commentText);
+      }
+    }
+
+    return condition.preserve(astNode, comment);
+  };
+};
+
+const minify = options => {
+  const {
+    file,
+    input,
+    inputSourceMap,
+    extractComments,
+    minify: minifyFn
+  } = options;
+
+  if (minifyFn) {
+    return minifyFn({
+      [file]: input
+    }, inputSourceMap);
+  } // Copy uglify options
+
+
+  const uglifyOptions = buildUglifyOptions(options.uglifyOptions); // Add source map data
+
+  if (inputSourceMap) {
+    uglifyOptions.sourceMap = {
+      content: inputSourceMap
+    };
+  }
+
+  const extractedComments = [];
+
+  if (extractComments) {
+    uglifyOptions.output.comments = buildComments(options, uglifyOptions, extractedComments);
+  }
+
+  const {
+    error,
+    map,
+    code,
+    warnings
+  } = _uglifyJs.default.minify({
+    [file]: input
+  }, uglifyOptions);
+
+  return {
+    error,
+    map,
+    code,
+    warnings,
+    extractedComments
+  };
+};
+
+var _default = minify;
+exports.default = _default;

--- a/dist/options.json
+++ b/dist/options.json
@@ -1,0 +1,169 @@
+{
+  "additionalProperties": false,
+  "definitions": {
+    "file-conditions": {
+      "anyOf": [
+        {
+          "instanceof": "RegExp"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    }
+  },
+  "properties": {
+    "test": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file-conditions"
+        },
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/file-conditions"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "include": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file-conditions"
+        },
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/file-conditions"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "exclude": {
+      "anyOf": [
+        {
+          "$ref": "#/definitions/file-conditions"
+        },
+        {
+          "items": {
+            "anyOf": [
+              {
+                "$ref": "#/definitions/file-conditions"
+              }
+            ]
+          },
+          "type": "array"
+        }
+      ]
+    },
+    "chunkFilter": {
+      "instanceof": "Function"
+    },
+    "cache": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        }
+      ]
+    },
+    "cacheKeys": {
+      "instanceof": "Function"
+    },
+    "parallel": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "integer"
+        }
+      ]
+    },
+    "sourceMap": {
+      "type": "boolean"
+    },
+    "minify": {
+      "instanceof": "Function"
+    },
+    "uglifyOptions": {
+      "additionalProperties": true,
+      "type": "object"
+    },
+    "extractComments": {
+      "anyOf": [
+        {
+          "type": "boolean"
+        },
+        {
+          "type": "string"
+        },
+        {
+          "instanceof": "RegExp"
+        },
+        {
+          "instanceof": "Function"
+        },
+        {
+          "additionalProperties": false,
+          "properties": {
+            "condition": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "instanceof": "RegExp"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
+            },
+            "filename": {
+              "anyOf": [
+                {
+                  "type": "string"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
+            },
+            "banner": {
+              "anyOf": [
+                {
+                  "type": "boolean"
+                },
+                {
+                  "type": "string"
+                },
+                {
+                  "instanceof": "Function"
+                }
+              ]
+            }
+          },
+          "type": "object"
+        }
+      ]
+    },
+    "warningsFilter": {
+      "instanceof": "Function"
+    }
+  },
+  "type": "object"
+}

--- a/dist/worker.js
+++ b/dist/worker.js
@@ -1,0 +1,17 @@
+"use strict";
+
+var _minify = _interopRequireDefault(require("./minify"));
+
+function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
+
+module.exports = (options, callback) => {
+  try {
+    // 'use strict' => this === undefined (Clean Scope)
+    // Safer for possible security issues, albeit not critical at all here
+    // eslint-disable-next-line no-new-func, no-param-reassign
+    options = new Function('exports', 'require', 'module', '__filename', '__dirname', `'use strict'\nreturn ${options}`)(exports, require, module, __filename, __dirname);
+    callback(null, (0, _minify.default)(options));
+  } catch (errors) {
+    callback(errors);
+  }
+};

--- a/src/TaskRunner.js
+++ b/src/TaskRunner.js
@@ -78,11 +78,7 @@ export default class TaskRunner {
 
           if (this.cacheDir && !result.error) {
             cacache
-              .put(
-                this.cacheDir,
-                serialize(task.cacheKeys),
-                JSON.stringify(data)
-              )
+              .put(this.cacheDir, task.cacheKey, JSON.stringify(data))
               .then(done, done);
           } else {
             done();
@@ -92,7 +88,7 @@ export default class TaskRunner {
 
       if (this.cacheDir) {
         cacache
-          .get(this.cacheDir, serialize(task.cacheKeys))
+          .get(this.cacheDir, task.cacheKey)
           .then(({ data }) => step(index, JSON.parse(data)), enqueue);
       } else {
         enqueue();

--- a/src/index.js
+++ b/src/index.js
@@ -11,6 +11,8 @@ import ModuleFilenameHelpers from 'webpack/lib/ModuleFilenameHelpers';
 import validateOptions from 'schema-utils';
 import serialize from 'serialize-javascript';
 import uglifyJsPackageJson from 'uglify-js/package.json';
+import cacache from 'cacache';
+import findCacheDir from 'find-cache-dir';
 
 import schema from './options.json';
 import TaskRunner from './TaskRunner';
@@ -170,224 +172,235 @@ class UglifyJsPlugin {
       const tasks = [];
 
       const { chunkFilter } = this.options;
+      const cacheDir = findCacheDir({ name: 'uglifyjs-webpack-plugin' });
 
-      Array.from(chunks)
-        .filter((chunk) => chunkFilter && chunkFilter(chunk))
-        .reduce((acc, chunk) => acc.concat(chunk.files || []), [])
-        .concat(compilation.additionalChunkAssets || [])
-        .filter(ModuleFilenameHelpers.matchObject.bind(null, this.options))
-        .forEach((file) => {
-          let inputSourceMap;
+      const promise = Promise.all(
+        Array.from(chunks)
+          .filter((chunk) => chunkFilter && chunkFilter(chunk))
+          .reduce((acc, chunk) => acc.concat(chunk.files || []), [])
+          .concat(compilation.additionalChunkAssets || [])
+          .filter(ModuleFilenameHelpers.matchObject.bind(null, this.options))
+          .map(async (file) => {
+            let inputSourceMap;
 
-          const asset = compilation.assets[file];
+            const asset = compilation.assets[file];
 
-          if (processedAssets.has(asset)) {
-            return;
-          }
+            if (processedAssets.has(asset)) {
+              return;
+            }
 
-          try {
-            let input;
+            try {
+              let cacheKey;
+              let cacheHit = false;
+              const input = asset.source();
 
-            if (this.options.sourceMap && asset.sourceAndMap) {
-              const { source, map } = asset.sourceAndMap();
+              if (this.options.cache) {
+                const defaultCacheKeys = {
+                  // eslint-disable-next-line global-require
+                  'uglify-js': uglifyJsPackageJson.version,
+                  // eslint-disable-next-line global-require
+                  'uglifyjs-webpack-plugin': require('../package.json').version,
+                  'uglifyjs-webpack-plugin-options': this.options,
+                  hash: crypto
+                    .createHash('md4')
+                    .update(input)
+                    .digest('hex'),
+                };
 
-              input = source;
+                cacheKey = this.options.cacheKeys
+                  ? serialize(this.options.cacheKeys(defaultCacheKeys, file))
+                  : defaultCacheKeys;
 
-              if (UglifyJsPlugin.isSourceMap(map)) {
-                inputSourceMap = map;
+                cacheHit = !!(await cacache.get.info(cacheDir, cacheKey));
+              }
+
+              if (this.options.sourceMap && asset.map && !cacheHit) {
+                const map = asset.map(this.options);
+
+                if (UglifyJsPlugin.isSourceMap(map)) {
+                  inputSourceMap = map;
+                } else {
+                  inputSourceMap = map;
+
+                  compilation.warnings.push(
+                    new Error(`${file} contains invalid source map`)
+                  );
+                }
               } else {
-                inputSourceMap = map;
-
-                compilation.warnings.push(
-                  new Error(`${file} contains invalid source map`)
-                );
+                inputSourceMap = null;
               }
-            } else {
-              input = asset.source();
-              inputSourceMap = null;
-            }
 
-            // Handling comment extraction
-            let commentsFile = false;
+              // Handling comment extraction
+              let commentsFile = false;
 
-            if (this.options.extractComments) {
-              commentsFile =
-                this.options.extractComments.filename || `${file}.LICENSE`;
+              if (this.options.extractComments) {
+                commentsFile =
+                  this.options.extractComments.filename || `${file}.LICENSE`;
 
-              if (typeof commentsFile === 'function') {
-                commentsFile = commentsFile(file);
+                if (typeof commentsFile === 'function') {
+                  commentsFile = commentsFile(file);
+                }
               }
-            }
 
-            const task = {
-              file,
-              input,
-              inputSourceMap,
-              commentsFile,
-              extractComments: this.options.extractComments,
-              uglifyOptions: this.options.uglifyOptions,
-              minify: this.options.minify,
-            };
-
-            if (this.options.cache) {
-              const defaultCacheKeys = {
-                // eslint-disable-next-line global-require
-                'uglify-js': uglifyJsPackageJson.version,
-                // eslint-disable-next-line global-require
-                'uglifyjs-webpack-plugin': require('../package.json').version,
-                'uglifyjs-webpack-plugin-options': this.options,
-                hash: crypto
-                  .createHash('md4')
-                  .update(input)
-                  .digest('hex'),
+              const task = {
+                file,
+                input,
+                inputSourceMap,
+                commentsFile,
+                extractComments: this.options.extractComments,
+                uglifyOptions: this.options.uglifyOptions,
+                minify: this.options.minify,
+                cacheKey,
               };
 
-              task.cacheKeys = this.options.cacheKeys(defaultCacheKeys, file);
+              tasks.push(task);
+            } catch (error) {
+              compilation.errors.push(
+                UglifyJsPlugin.buildError(
+                  error,
+                  file,
+                  UglifyJsPlugin.buildSourceMap(inputSourceMap),
+                  new RequestShortener(compiler.context)
+                )
+              );
             }
+          })
+      );
 
-            tasks.push(task);
-          } catch (error) {
-            compilation.errors.push(
-              UglifyJsPlugin.buildError(
-                error,
-                file,
-                UglifyJsPlugin.buildSourceMap(inputSourceMap),
-                new RequestShortener(compiler.context)
-              )
-            );
-          }
-        });
-
-      taskRunner.run(tasks, (tasksError, results) => {
-        if (tasksError) {
-          compilation.errors.push(tasksError);
-
-          return;
-        }
-
-        results.forEach((data, index) => {
-          const { file, input, inputSourceMap, commentsFile } = tasks[index];
-          const { error, map, code, warnings } = data;
-          let { extractedComments } = data;
-
-          let sourceMap = null;
-
-          if (error || (warnings && warnings.length > 0)) {
-            sourceMap = UglifyJsPlugin.buildSourceMap(inputSourceMap);
-          }
-
-          // Handling results
-          // Error case: add errors, and go to next file
-          if (error) {
-            compilation.errors.push(
-              UglifyJsPlugin.buildError(
-                error,
-                file,
-                sourceMap,
-                new RequestShortener(compiler.context)
-              )
-            );
+      promise.then(() => {
+        taskRunner.run(tasks, (tasksError, results) => {
+          if (tasksError) {
+            compilation.errors.push(tasksError);
 
             return;
           }
 
-          let outputSource;
+          results.forEach((data, index) => {
+            const { file, input, inputSourceMap, commentsFile } = tasks[index];
+            const { error, map, code, warnings } = data;
+            let { extractedComments } = data;
 
-          if (map) {
-            outputSource = new SourceMapSource(
-              code,
-              file,
-              JSON.parse(map),
-              input,
-              inputSourceMap
-            );
-          } else {
-            outputSource = new RawSource(code);
-          }
+            let sourceMap = null;
 
-          // Write extracted comments to commentsFile
-          if (
-            commentsFile &&
-            extractedComments &&
-            extractedComments.length > 0
-          ) {
-            if (commentsFile in compilation.assets) {
-              const commentsFileSource = compilation.assets[
-                commentsFile
-              ].source();
-
-              extractedComments = extractedComments.filter(
-                (comment) => !commentsFileSource.includes(comment)
-              );
+            if (error || (warnings && warnings.length > 0)) {
+              sourceMap = UglifyJsPlugin.buildSourceMap(inputSourceMap);
             }
 
-            if (extractedComments.length > 0) {
-              // Add a banner to the original file
-              if (this.options.extractComments.banner !== false) {
-                let banner =
-                  this.options.extractComments.banner ||
-                  `For license information please see ${path.posix.basename(
-                    commentsFile
-                  )}`;
-
-                if (typeof banner === 'function') {
-                  banner = banner(commentsFile);
-                }
-
-                if (banner) {
-                  outputSource = new ConcatSource(
-                    `/*! ${banner} */\n`,
-                    outputSource
-                  );
-                }
-              }
-
-              const commentsSource = new RawSource(
-                `${extractedComments.join('\n\n')}\n`
+            // Handling results
+            // Error case: add errors, and go to next file
+            if (error) {
+              compilation.errors.push(
+                UglifyJsPlugin.buildError(
+                  error,
+                  file,
+                  sourceMap,
+                  new RequestShortener(compiler.context)
+                )
               );
 
-              if (commentsFile in compilation.assets) {
-                // commentsFile already exists, append new comments...
-                if (compilation.assets[commentsFile] instanceof ConcatSource) {
-                  compilation.assets[commentsFile].add('\n');
-                  compilation.assets[commentsFile].add(commentsSource);
-                } else {
-                  compilation.assets[commentsFile] = new ConcatSource(
-                    compilation.assets[commentsFile],
-                    '\n',
-                    commentsSource
-                  );
-                }
-              } else {
-                compilation.assets[commentsFile] = commentsSource;
-              }
+              return;
             }
-          }
 
-          // Updating assets
-          processedAssets.add((compilation.assets[file] = outputSource));
+            let outputSource;
 
-          // Handling warnings
-          if (warnings && warnings.length > 0) {
-            warnings.forEach((warning) => {
-              const builtWarning = UglifyJsPlugin.buildWarning(
-                warning,
+            if (map) {
+              outputSource = new SourceMapSource(
+                code,
                 file,
-                sourceMap,
-                new RequestShortener(compiler.context),
-                this.options.warningsFilter
+                JSON.parse(map),
+                input,
+                inputSourceMap
               );
+            } else {
+              outputSource = new RawSource(code);
+            }
 
-              if (builtWarning) {
-                compilation.warnings.push(builtWarning);
+            // Write extracted comments to commentsFile
+            if (
+              commentsFile &&
+              extractedComments &&
+              extractedComments.length > 0
+            ) {
+              if (commentsFile in compilation.assets) {
+                const commentsFileSource = compilation.assets[
+                  commentsFile
+                ].source();
+
+                extractedComments = extractedComments.filter(
+                  (comment) => !commentsFileSource.includes(comment)
+                );
               }
-            });
-          }
+
+              if (extractedComments.length > 0) {
+                // Add a banner to the original file
+                if (this.options.extractComments.banner !== false) {
+                  let banner =
+                    this.options.extractComments.banner ||
+                    `For license information please see ${path.posix.basename(
+                      commentsFile
+                    )}`;
+
+                  if (typeof banner === 'function') {
+                    banner = banner(commentsFile);
+                  }
+
+                  if (banner) {
+                    outputSource = new ConcatSource(
+                      `/*! ${banner} */\n`,
+                      outputSource
+                    );
+                  }
+                }
+
+                const commentsSource = new RawSource(
+                  `${extractedComments.join('\n\n')}\n`
+                );
+
+                if (commentsFile in compilation.assets) {
+                  // commentsFile already exists, append new comments...
+                  if (
+                    compilation.assets[commentsFile] instanceof ConcatSource
+                  ) {
+                    compilation.assets[commentsFile].add('\n');
+                    compilation.assets[commentsFile].add(commentsSource);
+                  } else {
+                    compilation.assets[commentsFile] = new ConcatSource(
+                      compilation.assets[commentsFile],
+                      '\n',
+                      commentsSource
+                    );
+                  }
+                } else {
+                  compilation.assets[commentsFile] = commentsSource;
+                }
+              }
+            }
+
+            // Updating assets
+            processedAssets.add((compilation.assets[file] = outputSource));
+
+            // Handling warnings
+            if (warnings && warnings.length > 0) {
+              warnings.forEach((warning) => {
+                const builtWarning = UglifyJsPlugin.buildWarning(
+                  warning,
+                  file,
+                  sourceMap,
+                  new RequestShortener(compiler.context),
+                  this.options.warningsFilter
+                );
+
+                if (builtWarning) {
+                  compilation.warnings.push(builtWarning);
+                }
+              });
+            }
+          });
+
+          taskRunner.exit();
+
+          callback();
         });
-
-        taskRunner.exit();
-
-        callback();
       });
     };
 

--- a/test/cache-option.test.js
+++ b/test/cache-option.test.js
@@ -71,6 +71,7 @@ describe('when applied with `cache` option', () => {
     new UglifyJsPlugin({ cache: true }).apply(compiler);
 
     cacache.get = jest.fn(cacache.get);
+    cacache.get.info = jest.fn(cacache.get.info);
     cacache.put = jest.fn(cacache.put);
 
     return compile(compiler).then((stats) => {
@@ -106,6 +107,7 @@ describe('when applied with `cache` option', () => {
 
             cacache.get.mockClear();
             cacache.put.mockClear();
+            cacache.get.info.mockClear();
           })
           // Run second compilation to ensure cached files will be taken from cache
           .then(() => compile(compiler))
@@ -146,6 +148,7 @@ describe('when applied with `cache` option', () => {
     new UglifyJsPlugin({ cache: otherCacheDir }).apply(compiler);
 
     cacache.get = jest.fn(cacache.get);
+    cacache.get.info = jest.fn(cacache.get.info);
     cacache.put = jest.fn(cacache.put);
 
     return compile(compiler).then((stats) => {
@@ -180,6 +183,7 @@ describe('when applied with `cache` option', () => {
             expect(cacheKeys.length).toBe(countAssets);
 
             cacache.get.mockClear();
+            cacache.get.info.mockClear();
             cacache.put.mockClear();
           })
           // Run second compilation to ensure cached files will be taken from cache
@@ -231,6 +235,7 @@ describe('when applied with `cache` option', () => {
     }).apply(compiler);
 
     cacache.get = jest.fn(cacache.get);
+    cacache.get.info = jest.fn(cacache.get.info);
     cacache.put = jest.fn(cacache.put);
 
     return compile(compiler).then((stats) => {
@@ -277,6 +282,7 @@ describe('when applied with `cache` option', () => {
             });
 
             cacache.get.mockClear();
+            cacache.get.info.mockClear();
             cacache.put.mockClear();
           })
           // Run second compilation to ensure cached files will be taken from cache

--- a/test/sourceMap-option.test.js
+++ b/test/sourceMap-option.test.js
@@ -124,11 +124,8 @@ describe('when options.sourceMap', () => {
                   source() {
                     return assetContent;
                   },
-                  sourceAndMap() {
-                    return {
-                      source: this.source(),
-                      map: {},
-                    };
+                  map() {
+                    return {};
                   },
                 };
               }


### PR DESCRIPTION
This PR contains a:

- [ ] **bugfix**
- [x] new **feature**
- [ ] **code refactor**
- [ ] **test update** <!-- if bug or feature is checked, this should be too -->
- [ ] **typo fix**
- [ ] **metadata update**

### Motivation / Use-Case

The plugin does a lot of work computing input source maps when it isn't necessary, i.e. the cache key hasn't changed and we already have a source map in our cache for the key.  For our particular use case I saw a reduction in fully cached build times from UglifyJSPlugin taking 90s to 10s of the build time.

### Breaking Changes

This shouldn't be a breaking change, but I'm not super familiar with all of the possible configurations for this plugin.

### Additional Info

This change looks a lot bigger than it actually is.  Because of the `cacache.get.info()` call that's introduced index, I had to wrap a big chunk of `optimizeFn` in a `Promise.all()` call because `cacache.get.info()` returns a promise and before this everything in `optimizeFn` was synchronous.

NOTE: I've also include the build files in `dist` so that we can `npm install` the module from this commit without having to do a publish.

I've benchmarked doing a fresh build and a repeat build both with and without these changes in webapp.  Here are the results:
```
fresh build without changes: 
430150ms chunk asset optimization (uglifyjs) = 8m 10s
real    10m20.638s
user    26m1.687s
sys    2m25.869s

repeat build without changes:
154745ms chunk asset optimization (uglifyjs) = 2m 35s
real    3m20.630s
user    3m42.489s
sys    0m21.300s

fresh build with changes: 
437674ms chunk asset optimization (uglifyjs) = 7m 18s
real    10m9.119s
user    26m1.528s
sys    2m32.005s

repeat build with changes: 
7786ms chunk asset optimization (uglifyjs) = 0m 8s
real    0m45.423s
user    0m46.280s
sys    0m6.520s
```

### Test Plan

- run `yarn build:webpack-prod-profile --no-i18n` in webapp
- see `10535ms chunk asset optimization` which represents UglifyJSPlugin's time (this was close to 90 seconds before this change)
- see `12692ms after chunk asset optimization` which represents SourceMapDevToolPlugin's time (no change to this time, only included here to indicate that UglifyJSPlugin is no longer the bottleneck)
- run `md5` on some of the files in `genwebpack/prod/en/javascript` and see that they match the values before the changes.
- run `npm test`
- checksum all of the files output by webpack using `find genwebpack/prod/en -type f -exec shasum "{}" ';' > checksumsN.txt` and `diff checksumA.txt checksumB.txt` to compare them and see that they all match up.

<img width="781" alt="screen shot 2019-01-16 at 11 14 41 am" src="https://user-images.githubusercontent.com/1044413/51262226-f3014b00-197f-11e9-8173-b8351f0c1cd7.png">